### PR TITLE
Changed kern_class_values type

### DIFF
--- a/lib/writers/lvgl/lv_table_kern.js
+++ b/lib/writers/lvgl/lv_table_kern.js
@@ -75,7 +75,7 @@ ${u.long_dump(right_mapping)}
 };
 
 /*Kern values between classes*/
-static const uint8_t kern_class_values[] =
+static const int8_t kern_class_values[] =
 {
 ${u.long_dump(values.map(v => f.kernToFP(v)))}
 };


### PR DESCRIPTION
Changed from uint8_t to int8_t since the table contains values <= 0 and some compilers complain about assigning a negative number to an unsigned data type.  Kerning values of FP4.4 with sign should be ok using int8_t.