### PR TITLE
Make font_dsc const

### DIFF
--- a/lib/writers/lvgl/lv_table_head.js
+++ b/lib/writers/lvgl/lv_table_head.js
@@ -47,7 +47,7 @@ class LvHead extends Head {
  *--------------------*/
 
 /*Store all the custom data of the font*/
-static lv_font_fmt_txt_dsc_t font_dsc = {
+static const lv_font_fmt_txt_dsc_t font_dsc = {
     .glyph_bitmap = gylph_bitmap,
     .glyph_dsc = glyph_dsc,
     .cmaps = cmaps,
@@ -71,7 +71,7 @@ lv_font_t ${f.font_name} = {
     .line_height = ${f.src.ascent - f.src.descent},          /*The maximum line height required by the font*/
     .base_line = ${-f.src.descent},             /*Baseline measured from the bottom of the line*/
     .subpx = ${subpixels},
-    .dsc = &font_dsc           /*The custom font data. Will be accessed by \`get_glyph_bitmap/dsc\` */
+    .dsc = (void *)&font_dsc           /*The custom font data. Will be accessed by \`get_glyph_bitmap/dsc\` */
 };
 `.trim();
   }


### PR DESCRIPTION
font_dsc should be const otherwise it uses RW memory rather than RO.

This change needs to be coordinated with the declaration of _lv_font_struct in lvgl\src\lv_font\lv_font.h where dsc should be declared as const void * dsc;